### PR TITLE
Fixed not working text widgets

### DIFF
--- a/UnityImGUI/Assets/Scripts/ImGuiController.cs
+++ b/UnityImGUI/Assets/Scripts/ImGuiController.cs
@@ -123,10 +123,13 @@ public class ImGuiController
         io.MousePos = mousePosition;
         io.MouseWheel = Input.mouseScrollDelta.y;
 
-        //#TODO : Implement each Key!
-        foreach (char c in Input.inputString)
+        // Call to io.AddInputCharacter is required to make text wiget working
+        io.AddInputCharactersUTF8(Input.inputString);
+
+        // Check all keys. We can rely on Input.inputString with this, because we miss arrows and few other keys.
+        for (int key = 0; key < 512; ++key)
         {
-            io.KeysDown[(int)c] = true;
+            io.KeysDown[key] = Input.GetKey((KeyCode)key);
         }
 
         io.KeyCtrl = Input.GetKey(KeyCode.LeftControl);


### PR DESCRIPTION
This is solution to my reported issue: https://github.com/JayPeet/UnityImGUI/issues/1

Text widgets rely on InputQueueCharacters not on KeysDown array. To fill InputQueueCharacters you need to pass charackters with AddInputCharacter.